### PR TITLE
Support live stream handling: download last-minute clips and skip unavailable streams

### DIFF
--- a/handlers/twitter_handler.py
+++ b/handlers/twitter_handler.py
@@ -1,6 +1,7 @@
 # handlers/twitter_handler.py
 import yt_dlp
 import os
+import time
 from handlers.base_handler import BaseHandler
 from _ast import Try
 from utils.misc_utils import *
@@ -13,6 +14,9 @@ class FilenameCollectorPP(yt_dlp.postprocessor.common.PostProcessor):
     def run(self, information):
         self.filenames.append(information["filepath"])
         return [], information
+
+STREAM_CLIP_SECONDS = 60
+
 
 class TwitterHandler(BaseHandler):
     def __init__(self, *args, **kwargs):
@@ -46,10 +50,26 @@ class TwitterHandler(BaseHandler):
     def process_message(self, msg, attachments):
         url = self.extract_url(self.input_str)
         info = self._probe_download_info(url)
-        video_content = download_video(url, info=info)
-        if video_content:
+
+        if _is_unavailable_stream(info):
             return {
-                "message": "Downloaded video content using yt_dlp.",
+                "message": "This looks like a stream, but it is not currently available to download.",
+                "attachments": [],
+            }
+
+        is_stream = _is_live_stream(info)
+        video_content = download_video(
+            url,
+            info=None if is_stream else info,
+            stream_clip_seconds=STREAM_CLIP_SECONDS if is_stream else None,
+        )
+        if video_content:
+            if is_stream:
+                message = "Downloaded up to 1 minute from this stream using yt_dlp."
+            else:
+                message = "Downloaded video content using yt_dlp."
+            return {
+                "message": message,
                 "attachments": [BaseHandler.file_to_base64(video_content)],
             }
         return []
@@ -111,6 +131,48 @@ def _pick_best_download_format(formats, max_filesize_mb):
     return best_pair
 
 
+def _live_status(info):
+    return (info or {}).get("live_status")
+
+
+def _is_live_stream(info):
+    live_status = _live_status(info)
+    return bool((info or {}).get("is_live")) or live_status == "is_live"
+
+
+def _is_unavailable_stream(info):
+    live_status = _live_status(info)
+    return live_status in {"is_upcoming", "post_live"}
+
+
+def _stream_tail_download_ranges(seconds):
+    def download_ranges(info_dict, ydl):
+        duration = info_dict.get("duration")
+        if not duration:
+            live_start = (
+                info_dict.get("live_start_time")
+                or info_dict.get("release_timestamp")
+                or info_dict.get("timestamp")
+            )
+            if live_start:
+                duration = max(time.time() - live_start, 0)
+
+        if duration:
+            end_time = max(float(duration), 0)
+            start_time = max(end_time - seconds, 0)
+        else:
+            start_time = 0
+            end_time = seconds
+
+        yield {
+            "start_time": start_time,
+            "end_time": min(end_time, start_time + seconds),
+            "title": f"Last {seconds} seconds of stream",
+        }
+
+    return download_ranges
+
+
 def _base_ydl_opts():
     return {
         'quiet': True,
@@ -120,7 +182,7 @@ def _base_ydl_opts():
     }
 
 
-def download_video(url, max_filesize_mb=90, suggested_filename="downloaded_video", info=None):
+def download_video(url, max_filesize_mb=90, suggested_filename="downloaded_video", info=None, stream_clip_seconds=None):
     """
     Downloads the best quality video below the specified file size limit.
 
@@ -129,7 +191,7 @@ def download_video(url, max_filesize_mb=90, suggested_filename="downloaded_video
     :param suggested_filename: Suggested filename for the downloaded video (without extension)
     :return: Actual filename of the downloaded video
     """
-    
+
     class FilesizeLimitError(Exception):
         pass
 
@@ -147,20 +209,30 @@ def download_video(url, max_filesize_mb=90, suggested_filename="downloaded_video
             raise FilesizeLimitError("File size exceeds limit!")
 
     # try and delete the filename we're gonna use
-    test = os.listdir("./")        
+    test = os.listdir("./")
     for item in test:
         if item.startswith(suggested_filename):
-            os.remove(os.path.join("./", item)) 
-            
-    
+            os.remove(os.path.join("./", item))
+
+
     # Get available formats
     base_ydl_opts = _base_ydl_opts()
+    if stream_clip_seconds:
+        base_ydl_opts['live_from_start'] = True
     if info is None:
         ydl = yt_dlp.YoutubeDL(base_ydl_opts)
         info = ydl.extract_info(url, download=False)
 
     formats = info.get("formats", [])
     selected_format = _pick_best_download_format(formats, max_filesize_mb)
+
+    stream_range_opts = {}
+    if stream_clip_seconds:
+        stream_range_opts = {
+            'download_ranges': _stream_tail_download_ranges(stream_clip_seconds),
+            'force_keyframes_at_cuts': False,
+            'live_from_start': True,
+        }
 
     if selected_format:
         print(f"Found a format within size limit ({max_filesize_mb} MB). Downloading...")
@@ -177,6 +249,7 @@ def download_video(url, max_filesize_mb=90, suggested_filename="downloaded_video
             'playlistend': 1,                    # helps with twitter/dsky posts that have video in the comments
             'js_runtimes': base_ydl_opts['js_runtimes'],
             'extractor_args': base_ydl_opts['extractor_args'],
+            **stream_range_opts,
         }
     else:
         print("No suitable format found. Downloading best quality and compressing if needed.")
@@ -191,6 +264,7 @@ def download_video(url, max_filesize_mb=90, suggested_filename="downloaded_video
             'playlistend': 1,                    # helps with twitter/dsky posts that have video in the comments
             'js_runtimes': base_ydl_opts['js_runtimes'],
             'extractor_args': base_ydl_opts['extractor_args'],
+            **stream_range_opts,
         }
 
 
@@ -229,7 +303,7 @@ def download_video(url, max_filesize_mb=90, suggested_filename="downloaded_video
     os.rename(actual_filename, temp_input)
     output_fname = convert_to_mp4(temp_input, actual_filename, max_size_mb=max_filesize_mb, max_resolution=(2000, 2000))
     os.rename(output_fname, actual_filename)
-    
+
     return actual_filename
 
 

--- a/tests/test_twitter_handler_format_selection.py
+++ b/tests/test_twitter_handler_format_selection.py
@@ -1,7 +1,16 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from handlers.twitter_handler import TwitterHandler, _base_ydl_opts, _pick_best_download_format
+from handlers.twitter_handler import (
+    STREAM_CLIP_SECONDS,
+    TwitterHandler,
+    _base_ydl_opts,
+    _is_live_stream,
+    _is_unavailable_stream,
+    _pick_best_download_format,
+    _stream_tail_download_ranges,
+    download_video,
+)
 
 
 class TwitterHandlerFormatSelectionTest(unittest.TestCase):
@@ -58,8 +67,99 @@ class TwitterHandlerFormatSelectionTest(unittest.TestCase):
         response = handler.process_message(None, None)
 
         self.assertEqual(ydl.extract_info.call_count, 1)
-        download_video_mock.assert_called_once_with("https://example.com/video", info=probe_info)
+        download_video_mock.assert_called_once_with(
+            "https://example.com/video",
+            info=probe_info,
+            stream_clip_seconds=None,
+        )
         self.assertEqual(response["attachments"], ["encoded"])
+
+    @patch("handlers.twitter_handler.BaseHandler.file_to_base64", return_value="encoded")
+    @patch("handlers.twitter_handler.download_video", return_value="video.mp4")
+    @patch("handlers.twitter_handler.yt_dlp.YoutubeDL")
+    def test_live_stream_downloads_one_minute_clip_and_labels_stream(
+        self, youtube_dl_cls, download_video_mock, _
+    ):
+        probe_info = {"is_live": True, "live_status": "is_live", "formats": []}
+        ydl = MagicMock()
+        ydl.extract_info.return_value = probe_info
+        youtube_dl_cls.return_value = ydl
+
+        handler = TwitterHandler("https://www.youtube.com/watch?v=live")
+
+        self.assertTrue(handler.can_handle())
+        response = handler.process_message(None, None)
+
+        download_video_mock.assert_called_once_with(
+            "https://www.youtube.com/watch?v=live",
+            info=None,
+            stream_clip_seconds=STREAM_CLIP_SECONDS,
+        )
+        self.assertIn("stream", response["message"])
+        self.assertIn("1 minute", response["message"])
+        self.assertEqual(response["attachments"], ["encoded"])
+
+    @patch("handlers.twitter_handler.download_video")
+    @patch("handlers.twitter_handler.yt_dlp.YoutubeDL")
+    def test_upcoming_stream_is_not_downloaded(self, youtube_dl_cls, download_video_mock):
+        probe_info = {"live_status": "is_upcoming", "formats": []}
+        ydl = MagicMock()
+        ydl.extract_info.return_value = probe_info
+        youtube_dl_cls.return_value = ydl
+
+        handler = TwitterHandler("https://www.youtube.com/watch?v=upcoming")
+
+        self.assertTrue(handler.can_handle())
+        response = handler.process_message(None, None)
+
+        download_video_mock.assert_not_called()
+        self.assertIn("stream", response["message"])
+        self.assertEqual(response["attachments"], [])
+
+    def test_stream_tail_range_uses_last_minute_of_known_duration(self):
+        ranges = list(_stream_tail_download_ranges(60)({"duration": 125}, MagicMock()))
+
+        self.assertEqual(ranges[0]["start_time"], 65)
+        self.assertEqual(ranges[0]["end_time"], 125)
+
+    @patch("handlers.twitter_handler.time.time", return_value=1_000)
+    def test_stream_tail_range_falls_back_to_live_start_timestamp(self, _):
+        ranges = list(_stream_tail_download_ranges(60)({"live_start_time": 950}, MagicMock()))
+
+        self.assertEqual(ranges[0]["start_time"], 0)
+        self.assertEqual(ranges[0]["end_time"], 50)
+
+    def test_stream_status_helpers(self):
+        self.assertTrue(_is_live_stream({"is_live": True}))
+        self.assertTrue(_is_live_stream({"live_status": "is_live"}))
+        self.assertTrue(_is_unavailable_stream({"live_status": "is_upcoming"}))
+        self.assertTrue(_is_unavailable_stream({"live_status": "post_live"}))
+        self.assertFalse(_is_live_stream({"live_status": "not_live"}))
+
+    @patch("handlers.twitter_handler.os.rename")
+    @patch("handlers.twitter_handler.convert_to_mp4", return_value="downloaded_video.mp4.in")
+    @patch("handlers.twitter_handler.os.listdir", return_value=[])
+    @patch("handlers.twitter_handler.yt_dlp.YoutubeDL")
+    def test_download_video_applies_stream_range_options(
+        self, youtube_dl_cls, _, __, ___
+    ):
+        ydl = MagicMock()
+        ydl.__enter__.return_value = ydl
+        ydl.__exit__.return_value = None
+        ydl.extract_info.return_value = {"filepath": "downloaded_video.mp4"}
+        youtube_dl_cls.return_value = ydl
+
+        filename = download_video(
+            "https://www.youtube.com/watch?v=live",
+            info={"formats": []},
+            stream_clip_seconds=STREAM_CLIP_SECONDS,
+        )
+
+        ydl_opts = youtube_dl_cls.call_args.args[0]
+        self.assertEqual(filename, "downloaded_video.mp4")
+        self.assertTrue(ydl_opts["live_from_start"])
+        self.assertFalse(ydl_opts["force_keyframes_at_cuts"])
+        self.assertTrue(callable(ydl_opts["download_ranges"]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Improve handling of live streams so the handler can download a short clip from ongoing streams and avoid attempting to download streams that are not yet available.
- Provide a robust way to request only the tail of a live stream to limit download size and processing time.

### Description
- Add `STREAM_CLIP_SECONDS` and helpers ` _live_status`, `_is_live_stream`, `_is_unavailable_stream`, and `_stream_tail_download_ranges` to detect stream status and produce download ranges. 
- Update `TwitterHandler.process_message` to skip unavailable streams, detect live streams, and request a clipped download for live streams by passing `stream_clip_seconds` and `info=None` to `download_video` when appropriate, and to adjust response messages.
- Extend `download_video` signature to `download_video(..., stream_clip_seconds=None)` and merge stream-specific options (`download_ranges`, `force_keyframes_at_cuts`, `live_from_start`) into `ydl_opts` when `stream_clip_seconds` is provided.
- Minor refactors: expose `STREAM_CLIP_SECONDS` to tests and keep existing format-selection and conversion logic intact.

### Testing
- Updated and ran the unit tests in `tests/test_twitter_handler_format_selection.py`, which were extended to cover live detection helpers, stream-unavailable handling, that live downloads request a 1-minute clip, and that `download_video` applies stream range options, and all tests passed.
- Ran existing format-selection tests verifying `_base_ydl_opts` and `_pick_best_download_format` behavior, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c6fc76d8083269a61ca4038b497d8)