### PR TITLE
Support arbitrary ticker chart durations and improve intraday granularity

### DIFF
--- a/handlers/ticker_handler.py
+++ b/handlers/ticker_handler.py
@@ -1,21 +1,24 @@
-
-import os
+from datetime import datetime, timedelta, timezone
 from handlers.base_handler import BaseHandler
 from utils.misc_utils import *
 import yfinance as yf
 import re
 import matplotlib.pyplot as plt
 
+DEFAULT_DURATION = "1y"
+INTRADAY_THRESHOLD_DAYS = 5
+
+
 class TickerHandler(BaseHandler):
 
     def can_handle(self) -> bool:
         self.tickers = extract_ticker_symbols(self.input_str)
-        return (len(self.tickers)>0)
+        return (len(self.tickers) > 0)
 
     def process_message(self, msg, attachments):
         if self.tickers:
             return {
-                "message": get_stock_summary( convert_to_get_stock_summary_input(self.tickers) ),
+                "message": get_stock_summary(convert_to_get_stock_summary_input(self.tickers)),
                 "attachments": [plot_stock_data_base64(self.tickers)],
             }
         return []
@@ -23,12 +26,13 @@ class TickerHandler(BaseHandler):
     @staticmethod
     def get_name() -> str:
         return "TickerHandler"
-    
-    @staticmethod    
+
+    @staticmethod
     def get_help_text() -> str:
         retval = "Gets stock info for any ticker after '$'.  i.e. $amd. \n"
-        retval += "Optoinally add a during, i.e. $amd.5y   \n"
+        retval += "Optionally add a duration, i.e. $amd.5y, $msft.10d, $spy.18mo.   \n"
         return retval
+
 
 def get_stock_summary(ticker_symbols):
     """
@@ -44,13 +48,8 @@ def get_stock_summary(ticker_symbols):
 
     for ticker_symbol in ticker_symbols:
         try:
-            # Fetch stock data
             stock = yf.Ticker(ticker_symbol)
-            
-            # Extract basic information
             info = stock.info
-
-            # Prepare summary information
             summary = (f"\nBasic Stock Information for {ticker_symbol.upper()}:\n"
                        f"----------------------------\n"
                        f"Company Name: {info.get('longName', 'N/A')}\n"
@@ -65,90 +64,109 @@ def get_stock_summary(ticker_symbols):
                        f"52-Week Low: {info.get('fiftyTwoWeekLow', 'N/A')}\n"
                        f"CEO: {info.get('ceo', 'N/A')}")
             results.append(summary)
-        
         except Exception as e:
             results.append(f"An error occurred while fetching data for {ticker_symbol}: {e}")
 
     return "\n".join(results)
 
+
 def extract_ticker_symbols(input_string):
     """
     Extract ticker symbols from a string if they are prefixed with '$', including optional duration.
-
-    Parameters:
-        input_string (str): The input string to parse.
-
-    Returns:
-        list of tuples: A list of tuples where each tuple contains a ticker symbol and a duration.
     """
-    matches = re.findall(r'\$([a-zA-Z]\w*)(?:\.([a-zA-Z0-9]+))?', input_string)
-    return [(symbol, duration if duration else "1y") for symbol, duration in matches]
+    matches = re.findall(r'\$([a-zA-Z][\w-]*)(?:\.([a-zA-Z0-9]+))?', input_string)
+    return [(symbol, duration.lower() if duration else DEFAULT_DURATION) for symbol, duration in matches]
+
 
 def convert_to_get_stock_summary_input(ticker_tuples):
-    """
-    Convert the output of extract_ticker_symbols to the input format expected by get_stock_summary.
-
-    Parameters:
-        ticker_tuples (list of tuples): A list of tuples where each tuple contains a stock ticker symbol and a duration.
-
-    Returns:
-        list of str: A list of stock ticker symbols.
-    """
     return [symbol for symbol, _ in ticker_tuples]
+
+
+def duration_to_timedelta(duration):
+    """Convert a user supplied duration like 10d, 6w, 18mo, or 3y to a timedelta."""
+    match = re.fullmatch(r'(\d+)(d|w|mo|m|y)', duration.lower())
+    if not match:
+        raise ValueError(f"Unsupported duration '{duration}'. Use a number followed by d, w, mo/m, or y.")
+
+    amount = int(match.group(1))
+    unit = match.group(2)
+    if amount <= 0:
+        raise ValueError("Duration must be greater than zero.")
+
+    if unit == 'd':
+        return timedelta(days=amount)
+    if unit == 'w':
+        return timedelta(weeks=amount)
+    if unit in ('mo', 'm'):
+        return timedelta(days=amount * 30)
+    if unit == 'y':
+        return timedelta(days=amount * 365)
+    raise ValueError(f"Unsupported duration unit '{unit}'.")
+
+
+def get_history_options(duration, now=None):
+    """Build yfinance history options for arbitrary durations."""
+    now = now or datetime.now(timezone.utc)
+    delta = duration_to_timedelta(duration)
+    options = {"start": now - delta, "end": now}
+    if delta <= timedelta(days=INTRADAY_THRESHOLD_DAYS):
+        options["interval"] = "1h"
+    return options
+
+
+def format_price(value):
+    return f"${value:.2f}"
+
 
 def plot_stock_data_base64(ticker_symbols):
     """
-    Plot the historical closing prices for a list of ticker symbols as percentage changes,
-    ensuring all stocks start at the same point, and mark the dollar values at the beginning and end.
+    Plot historical prices for a list of ticker symbols as percentage changes.
 
-    Always includes $SPY and uses the longest supplied duration for all tickers.
-
-    Parameters:
-        ticker_symbols (list of tuples): A list of tuples where each tuple contains a stock ticker symbol and a duration.
-
-    Returns:
-        str: The base64 string of the generated plot.
+    Always includes $SPY. Uses the longest supplied duration for every ticker so each
+    line is plotted over the same requested time range. Intraday ranges up to five
+    days use hourly granularity.
     """
     plt.figure(figsize=(10, 6))
 
-    # Ensure $SPY is included
-    if not any(ticker_symbol.lower() == "spy" for ticker_symbol, _ in ticker_symbols):
-        ticker_symbols.insert(0,("SPY", "1y"))
+    tickers_to_plot = list(ticker_symbols)
+    longest_duration = max(
+        (duration for _, duration in tickers_to_plot),
+        key=lambda duration: duration_to_timedelta(duration),
+    )
+    if not any(ticker_symbol.lower() == "spy" for ticker_symbol, _ in tickers_to_plot):
+        tickers_to_plot.insert(0, ("SPY", longest_duration))
 
-    # Determine the longest duration
-    durations = [duration for _, duration in ticker_symbols]
-    longest_duration = max(durations, key=lambda d: int(d[:-1]) if d[-1] == 'y' else int(d[:-2]) / 12)
+    history_options = get_history_options(longest_duration)
 
-    for ticker_symbol, _ in ticker_symbols:
+    plotted_any_series = False
+
+    for ticker_symbol, _ in tickers_to_plot:
         try:
-            # Fetch historical market data with the longest duration
             stock = yf.Ticker(ticker_symbol)
-            hist = stock.history(period=longest_duration)
+            hist = stock.history(**history_options)
+            if hist.empty:
+                print(f"No historical data found for {ticker_symbol}")
+                continue
 
-            # Calculate percentage change and normalize
             hist["Normalized"] = (hist["Close"] / hist["Close"].iloc[0]) * 100
-
-            # Plot normalized closing prices
-            plt.plot(hist.index, hist["Normalized"], label=f"{ticker_symbol.upper()} ({longest_duration})")
-
-            # Mark the starting and ending dollar values
-            plt.text(hist.index[0], hist["Normalized"].iloc[0], f"${hist['Close'].iloc[0]:.2f}", fontsize=8, color="black")
-            plt.text(hist.index[-1], hist["Normalized"].iloc[-1], f"${hist['Close'].iloc[-1]:.2f}", fontsize=8, color="black")
+            start_price = format_price(hist["Close"].iloc[0])
+            end_price = format_price(hist["Close"].iloc[-1])
+            label = f"{ticker_symbol.upper()} ({start_price} → {end_price})"
+            plt.plot(hist.index, hist["Normalized"], label=label)
+            plotted_any_series = True
         except Exception as e:
             print(f"An error occurred while fetching data for {ticker_symbol}: {e}")
 
-    # Add labels, title, and legend
     plt.xlabel("Date")
-    plt.ylabel("Percentage Change (%)")
-    plt.title("Historical Closing Prices (Normalized)")
-    plt.legend()
+    plt.ylabel("Normalized Price (%)")
+    interval_description = "hourly" if history_options.get("interval") == "1h" else "daily"
+    plt.title(f"Historical Prices (Normalized, {longest_duration}, {interval_description})")
+    if plotted_any_series:
+        plt.legend()
     plt.grid()
 
-    # Save the plot to a temporary file and convert to base64
     filename = "temp_plot.png"
     plt.savefig(filename)
     plt.close()
 
-    # Convert file to base64
-    base64_string = file_to_base64(filename)
-    return base64_string
+    return file_to_base64(filename)

--- a/tests/test_ticker_handler.py
+++ b/tests/test_ticker_handler.py
@@ -1,0 +1,70 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from handlers.ticker_handler import (
+    DEFAULT_DURATION,
+    duration_to_timedelta,
+    extract_ticker_symbols,
+    get_history_options,
+    plot_stock_data_base64,
+)
+
+
+def test_extract_ticker_symbols_supports_arbitrary_duration_units():
+    assert extract_ticker_symbols("compare $amd.10d $msft.6w $goog.18mo $spy") == [
+        ("amd", "10d"),
+        ("msft", "6w"),
+        ("goog", "18mo"),
+        ("spy", DEFAULT_DURATION),
+    ]
+
+
+def test_duration_to_timedelta_supports_days_weeks_months_and_years():
+    assert duration_to_timedelta("10d") == timedelta(days=10)
+    assert duration_to_timedelta("6w") == timedelta(weeks=6)
+    assert duration_to_timedelta("18mo") == timedelta(days=540)
+    assert duration_to_timedelta("2y") == timedelta(days=730)
+
+
+def test_get_history_options_uses_requested_range_and_hourly_intraday():
+    now = datetime(2026, 6, 15, tzinfo=timezone.utc)
+
+    hourly_options = get_history_options("4d", now=now)
+    assert hourly_options == {
+        "start": now - timedelta(days=4),
+        "end": now,
+        "interval": "1h",
+    }
+
+    daily_options = get_history_options("10d", now=now)
+    assert daily_options == {
+        "start": now - timedelta(days=10),
+        "end": now,
+    }
+
+
+@patch("handlers.ticker_handler.file_to_base64", return_value="encoded-plot")
+@patch("handlers.ticker_handler.plt")
+@patch("handlers.ticker_handler.yf.Ticker")
+def test_plot_uses_longest_requested_range_and_prices_in_legend(mock_ticker, mock_plt, mock_file_to_base64):
+    hist = pd.DataFrame(
+        {"Close": [10.0, 12.0]},
+        index=pd.date_range("2026-06-01", periods=2, tz="UTC"),
+    )
+    ticker_instance = MagicMock()
+    ticker_instance.history.return_value = hist
+    mock_ticker.return_value = ticker_instance
+
+    result = plot_stock_data_base64([("AMD", "10d")])
+
+    assert result == "encoded-plot"
+    history_kwargs = ticker_instance.history.call_args.kwargs
+    assert set(history_kwargs) == {"start", "end"}
+    actual_range = history_kwargs["end"] - history_kwargs["start"]
+    assert timedelta(days=9, hours=23, minutes=59) < actual_range < timedelta(days=10, minutes=1)
+    assert mock_ticker.call_count == 2
+    assert mock_plt.text.call_count == 0
+    labels = [call.kwargs["label"] for call in mock_plt.plot.call_args_list]
+    assert labels == ["SPY ($10.00 → $12.00)", "AMD ($10.00 → $12.00)"]


### PR DESCRIPTION
### Motivation
- The previous ticker handler only accepted a few fixed ranges and fell back to a one-year history even when a shorter range was requested.
- Short ranges need better granularity than daily close values so users can inspect intraday movement.
- Normalizing every series to 100% and printing start prices on the plot made the initial dollar values overlap and hard to read.

### Description
- Added parsing for arbitrary duration suffixes (e.g., `10d`, `6w`, `18mo`, `2y`) and preserved a `DEFAULT_DURATION` of `1y` when unspecified.
- Implemented `duration_to_timedelta` and `get_history_options` so yfinance history is requested with explicit `start`/`end` bounds and uses `interval='1h'` for ranges up to `INTRADAY_THRESHOLD_DAYS` (5 days).
- Ensure auto-inserted `SPY` uses the computed longest requested duration instead of forcing a 1y range, so all series are fetched over the same requested window.
- Move start/end dollar prices into the legend label (`$start → $end`) and remove overlapping `plt.text` annotations, with the legend displayed only when series are plotted.
- Added unit tests (`tests/test_ticker_handler.py`) that cover duration parsing, history option generation, range honoring, and legend label content.

### Testing
- Ran `python -m pytest tests/test_ticker_handler.py` which passed all ticker-specific tests (4 passed).
- Ran `python -m pytest tests/test_run.py tests/test_ticker_handler.py` and all tests succeeded (`15 passed`) with one unrelated warning about a missing OpenAI API key.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3001dd8ae88326a55ed7749d388642)