### PR TITLE
Switch default GPT image model to gpt-image-1-mini and update tests

### DIFF
--- a/handlers/gpt_handler.py
+++ b/handlers/gpt_handler.py
@@ -14,7 +14,7 @@ if key == "":
 client = OpenAI(api_key=key)
 
 DEFAULT_MODEL = "gpt-4.1"
-DEFAULT_IMAGE_MODEL = "dall-e-3"
+DEFAULT_IMAGE_MODEL = "gpt-image-1-mini"
 IMAGE_MODEL_PREFIXES = ("chatgpt-image-", "gpt-image-", "dall-e-")
 TOOL_DIR = os.path.join(os.path.dirname(__file__), "..", "tool_functions")
 
@@ -144,7 +144,7 @@ class GptHandler(HashtagHandler):
     @staticmethod
     def get_help_text() -> str:
         retval = "The first substring specifies the model being used, e.g., #gpt.gpt-4o-mini.\n"
-        retval += "Use #gpt.image to generate an image with the default image model.\n"
+        retval += f"Use #gpt.image to generate an image with the default image model ({DEFAULT_IMAGE_MODEL}).\n"
         retval += "Image model prefixes: chatgpt-image-*, gpt-image-*, dall-e-*.\n"
         retval += "Available models are:    \n"
 

--- a/tests/test_gpt_handler.py
+++ b/tests/test_gpt_handler.py
@@ -1,9 +1,13 @@
 import unittest
+from unittest.mock import patch
 
 from handlers.gpt_handler import (
+    DEFAULT_IMAGE_MODEL,
     WEB_SEARCH_TOOL,
     WEB_SEARCH_TOOL_CHOICE,
+    GptHandler,
     build_response_create_kwargs,
+    is_image_model,
     should_force_web_search,
 )
 
@@ -53,6 +57,24 @@ class GptHandlerWebSearchTest(unittest.TestCase):
         )
 
         self.assertNotIn("tool_choice", kwargs)
+
+
+class GptHandlerImageModelTest(unittest.TestCase):
+    def test_default_image_model_uses_current_accessible_gpt_image_model(self):
+        self.assertEqual(DEFAULT_IMAGE_MODEL, "gpt-image-1-mini")
+        self.assertTrue(is_image_model(DEFAULT_IMAGE_MODEL))
+
+    def test_image_alias_resolves_to_default_image_model(self):
+        handler = GptHandler("#gpt.image draw a tiny robot")
+        self.assertTrue(handler.can_handle())
+
+        with patch("handlers.gpt_handler.submit_gpt_image_gen") as submit_mock:
+            submit_mock.return_value = {"message": "ok", "attachments": []}
+
+            response = handler.process_message("#gpt.image draw a tiny robot", None)
+
+        self.assertEqual(response, {"message": "ok", "attachments": []})
+        submit_mock.assert_called_once_with("draw a tiny robot", None, DEFAULT_IMAGE_MODEL)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- The previous default image model `dall-e-3` is deprecated / not suitable for unverified accounts, so use a lower-tier image model that is accessible.
- Make `#gpt.image` behavior explicit by selecting a currently-available GPT image model as the default.
- Add tests to prevent regressions around the image alias and default selection.

### Description
- Changed the default image model constant from `dall-e-3` to `gpt-image-1-mini` in `handlers/gpt_handler.py` (updated `DEFAULT_IMAGE_MODEL`).
- Updated the GPT handler help text to include the concrete default image model (`DEFAULT_IMAGE_MODEL`).
- Added unit tests in `tests/test_gpt_handler.py` verifying `DEFAULT_IMAGE_MODEL`, that it is recognized by `is_image_model`, and that the `#gpt.image` alias dispatches to `submit_gpt_image_gen` with the expected model, and fixed the test import to use `from unittest.mock import patch`.

### Testing
- Ran `python -m pytest tests/test_gpt_handler.py` which completed successfully with all tests passing (`6 passed, 1 warning`).
- The test suite observed a warning about missing `OPENAI_API_KEY` but no failures were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3172ebf1388326bab8d701f60031ba)