### PR TITLE
Exclude zero/NaN close prices before normalizing ticker plots

### DIFF
--- a/handlers/ticker_handler.py
+++ b/handlers/ticker_handler.py
@@ -118,6 +118,13 @@ def format_price(value):
     return f"${value:.2f}"
 
 
+def clean_price_history(hist):
+    """Return rows with usable positive close prices for plotting."""
+    if hist.empty or "Close" not in hist:
+        return hist
+    return hist[hist["Close"].notna() & (hist["Close"] > 0)].copy()
+
+
 def plot_stock_data_base64(ticker_symbols):
     """
     Plot historical prices for a list of ticker symbols as percentage changes.
@@ -144,8 +151,9 @@ def plot_stock_data_base64(ticker_symbols):
         try:
             stock = yf.Ticker(ticker_symbol)
             hist = stock.history(**history_options)
+            hist = clean_price_history(hist)
             if hist.empty:
-                print(f"No historical data found for {ticker_symbol}")
+                print(f"No usable historical close prices found for {ticker_symbol}")
                 continue
 
             hist["Normalized"] = (hist["Close"] / hist["Close"].iloc[0]) * 100

--- a/tests/test_ticker_handler.py
+++ b/tests/test_ticker_handler.py
@@ -2,11 +2,13 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
+import pytest
 
 from handlers.ticker_handler import (
     DEFAULT_DURATION,
     duration_to_timedelta,
     extract_ticker_symbols,
+    clean_price_history,
     get_history_options,
     plot_stock_data_base64,
 )
@@ -68,3 +70,36 @@ def test_plot_uses_longest_requested_range_and_prices_in_legend(mock_ticker, moc
     assert mock_plt.text.call_count == 0
     labels = [call.kwargs["label"] for call in mock_plt.plot.call_args_list]
     assert labels == ["SPY ($10.00 → $12.00)", "AMD ($10.00 → $12.00)"]
+
+
+def test_clean_price_history_removes_zero_and_missing_close_values():
+    hist = pd.DataFrame(
+        {"Close": [10.0, None, 0.0, 12.0]},
+        index=pd.date_range("2026-06-01", periods=4, tz="UTC"),
+    )
+
+    cleaned = clean_price_history(hist)
+
+    assert cleaned["Close"].tolist() == [10.0, 12.0]
+
+
+@patch("handlers.ticker_handler.file_to_base64", return_value="encoded-plot")
+@patch("handlers.ticker_handler.plt")
+@patch("handlers.ticker_handler.yf.Ticker")
+def test_plot_ignores_zero_close_rows_when_labeling_and_normalizing(mock_ticker, mock_plt, mock_file_to_base64):
+    hist = pd.DataFrame(
+        {"Close": [10.0, 11.0, 0.0]},
+        index=pd.date_range("2026-06-01", periods=3, tz="UTC"),
+    )
+    ticker_instance = MagicMock()
+    ticker_instance.history.return_value = hist
+    mock_ticker.return_value = ticker_instance
+
+    result = plot_stock_data_base64([("SPCM", "10d")])
+
+    assert result == "encoded-plot"
+    labels = [call.kwargs["label"] for call in mock_plt.plot.call_args_list]
+    assert labels == ["SPY ($10.00 → $11.00)", "SPCM ($10.00 → $11.00)"]
+    plotted_values = [call.args[1].tolist() for call in mock_plt.plot.call_args_list]
+    assert plotted_values[0] == pytest.approx([100.0, 110.0])
+    assert plotted_values[1] == pytest.approx([100.0, 110.0])


### PR DESCRIPTION
### Motivation
- Prevent ticker plot lines and legend labels from being driven by missing or zero close prices (observed as a final value of 0 for symbols like $spcm/$spcg).
- Ensure normalization and label generation use the first and last valid close prices.

### Description
- Add `clean_price_history(hist)` to filter out rows with missing or non-positive `Close` values.
- Apply `clean_price_history` immediately after fetching yfinance history so normalization and legend use only usable prices and skip tickers with no valid rows.
- Update the plotted message when no usable data remains to clarify the reason.
- Add unit tests in `tests/test_ticker_handler.py` covering removal of zero/missing close values and the scenario where the latest row has a zero close; use `pytest.approx` for float comparisons.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_ticker_handler.py` and the ticker-handler tests passed (6 passed).
- Ran the full suite with `PYTHONPATH=. pytest -q` and observed unrelated network-dependent failures (10 failed, 35 passed) due to proxy/Tunnel 403 errors impacting external-download tests (asteroid, yt-dlp, reddit, etc.).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31deb64d6c832682160ac63a201575)