### PR TITLE
Disable yfinance auto-adjust and filter non-positive Close prices for plotting

### DIFF
--- a/handlers/ticker_handler.py
+++ b/handlers/ticker_handler.py
@@ -108,7 +108,7 @@ def get_history_options(duration, now=None):
     """Build yfinance history options for arbitrary durations."""
     now = now or datetime.now(timezone.utc)
     delta = duration_to_timedelta(duration)
-    options = {"start": now - delta, "end": now}
+    options = {"start": now - delta, "end": now, "auto_adjust": False}
     if delta <= timedelta(days=INTRADAY_THRESHOLD_DAYS):
         options["interval"] = "1h"
     return options
@@ -116,6 +116,13 @@ def get_history_options(duration, now=None):
 
 def format_price(value):
     return f"${value:.2f}"
+
+
+def clean_price_history(hist):
+    """Return rows with usable positive close prices for plotting."""
+    if hist.empty or "Close" not in hist:
+        return hist
+    return hist[hist["Close"].notna() & (hist["Close"] > 0)].copy()
 
 
 def plot_stock_data_base64(ticker_symbols):
@@ -144,8 +151,9 @@ def plot_stock_data_base64(ticker_symbols):
         try:
             stock = yf.Ticker(ticker_symbol)
             hist = stock.history(**history_options)
+            hist = clean_price_history(hist)
             if hist.empty:
-                print(f"No historical data found for {ticker_symbol}")
+                print(f"No usable historical close prices found for {ticker_symbol}")
                 continue
 
             hist["Normalized"] = (hist["Close"] / hist["Close"].iloc[0]) * 100

--- a/tests/test_ticker_handler.py
+++ b/tests/test_ticker_handler.py
@@ -2,11 +2,13 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
+import pytest
 
 from handlers.ticker_handler import (
     DEFAULT_DURATION,
     duration_to_timedelta,
     extract_ticker_symbols,
+    clean_price_history,
     get_history_options,
     plot_stock_data_base64,
 )
@@ -35,6 +37,7 @@ def test_get_history_options_uses_requested_range_and_hourly_intraday():
     assert hourly_options == {
         "start": now - timedelta(days=4),
         "end": now,
+        "auto_adjust": False,
         "interval": "1h",
     }
 
@@ -42,6 +45,7 @@ def test_get_history_options_uses_requested_range_and_hourly_intraday():
     assert daily_options == {
         "start": now - timedelta(days=10),
         "end": now,
+        "auto_adjust": False,
     }
 
 
@@ -61,10 +65,44 @@ def test_plot_uses_longest_requested_range_and_prices_in_legend(mock_ticker, moc
 
     assert result == "encoded-plot"
     history_kwargs = ticker_instance.history.call_args.kwargs
-    assert set(history_kwargs) == {"start", "end"}
+    assert set(history_kwargs) == {"start", "end", "auto_adjust"}
+    assert history_kwargs["auto_adjust"] is False
     actual_range = history_kwargs["end"] - history_kwargs["start"]
     assert timedelta(days=9, hours=23, minutes=59) < actual_range < timedelta(days=10, minutes=1)
     assert mock_ticker.call_count == 2
     assert mock_plt.text.call_count == 0
     labels = [call.kwargs["label"] for call in mock_plt.plot.call_args_list]
     assert labels == ["SPY ($10.00 → $12.00)", "AMD ($10.00 → $12.00)"]
+
+
+def test_clean_price_history_removes_zero_and_missing_close_values():
+    hist = pd.DataFrame(
+        {"Close": [10.0, None, 0.0, 12.0]},
+        index=pd.date_range("2026-06-01", periods=4, tz="UTC"),
+    )
+
+    cleaned = clean_price_history(hist)
+
+    assert cleaned["Close"].tolist() == [10.0, 12.0]
+
+
+@patch("handlers.ticker_handler.file_to_base64", return_value="encoded-plot")
+@patch("handlers.ticker_handler.plt")
+@patch("handlers.ticker_handler.yf.Ticker")
+def test_plot_ignores_zero_close_rows_when_labeling_and_normalizing(mock_ticker, mock_plt, mock_file_to_base64):
+    hist = pd.DataFrame(
+        {"Close": [10.0, 11.0, 0.0]},
+        index=pd.date_range("2026-06-01", periods=3, tz="UTC"),
+    )
+    ticker_instance = MagicMock()
+    ticker_instance.history.return_value = hist
+    mock_ticker.return_value = ticker_instance
+
+    result = plot_stock_data_base64([("SPCM", "10d")])
+
+    assert result == "encoded-plot"
+    labels = [call.kwargs["label"] for call in mock_plt.plot.call_args_list]
+    assert labels == ["SPY ($10.00 → $11.00)", "SPCM ($10.00 → $11.00)"]
+    plotted_values = [call.args[1].tolist() for call in mock_plt.plot.call_args_list]
+    assert plotted_values[0] == pytest.approx([100.0, 110.0])
+    assert plotted_values[1] == pytest.approx([100.0, 110.0])


### PR DESCRIPTION
### Motivation

- Ensure charts are built from raw close prices rather than automatically adjusted prices so legends and normalizations reflect actual `Close` values.
- Avoid plotting and labeling series that contain missing or zero `Close` values which can skew normalization and produce misleading legends.

### Description

- Add `"auto_adjust": False` to the history options produced by `get_history_options` so yfinance returns raw `Close` prices.
- Introduce `clean_price_history(hist)` which returns rows where `hist["Close"]` is present and greater than zero and use it in `plot_stock_data_base64` before plotting.
- Update `plot_stock_data_base64` to skip series with no usable close prices and change the corresponding log message to `No usable historical close prices found for {ticker_symbol}`.
- Update tests in `tests/test_ticker_handler.py` to expect `auto_adjust=False`, add `test_clean_price_history_removes_zero_and_missing_close_values`, and add `test_plot_ignores_zero_close_rows_when_labeling_and_normalizing` (also import `pytest`).

### Testing

- Ran the unit tests in `tests/test_ticker_handler.py`, including `test_get_history_options` and `test_plot_uses_longest_requested_range_and_prices_in_legend`, and they passed.
- Verified new `test_clean_price_history_removes_zero_and_missing_close_values` passed, confirming zeros and `NaN` are filtered out.
- Verified `test_plot_ignores_zero_close_rows_when_labeling_and_normalizing` passed, confirming labels and normalized series ignore zero `Close` rows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31deb64d6c832682160ac63a201575)