### PR TITLE
TickerHandler: filter stale close prices and disable auto_adjust for plotting

### DIFF
--- a/handlers/ticker_handler.py
+++ b/handlers/ticker_handler.py
@@ -7,6 +7,7 @@ import matplotlib.pyplot as plt
 
 DEFAULT_DURATION = "1y"
 INTRADAY_THRESHOLD_DAYS = 5
+MAX_REASONABLE_DAILY_PRICE_RATIO = 10
 
 
 class TickerHandler(BaseHandler):
@@ -108,7 +109,7 @@ def get_history_options(duration, now=None):
     """Build yfinance history options for arbitrary durations."""
     now = now or datetime.now(timezone.utc)
     delta = duration_to_timedelta(duration)
-    options = {"start": now - delta, "end": now}
+    options = {"start": now - delta, "end": now, "auto_adjust": False}
     if delta <= timedelta(days=INTRADAY_THRESHOLD_DAYS):
         options["interval"] = "1h"
     return options
@@ -116,6 +117,32 @@ def get_history_options(duration, now=None):
 
 def format_price(value):
     return f"${value:.2f}"
+
+
+def clean_price_history(hist):
+    """Return rows with usable positive close prices for plotting.
+
+    Some newly launched or ticker-reused funds can include stale predecessor
+    history in Yahoo data. If there is an extreme price discontinuity, keep the
+    most recent continuous segment so normalization is based on the current
+    instrument rather than legacy rows.
+    """
+    if hist.empty or "Close" not in hist:
+        return hist
+
+    cleaned = hist[hist["Close"].notna() & (hist["Close"] > 0)].copy()
+    if len(cleaned) < 2:
+        return cleaned
+
+    price_ratios = cleaned["Close"] / cleaned["Close"].shift(1)
+    discontinuities = price_ratios[
+        (price_ratios > MAX_REASONABLE_DAILY_PRICE_RATIO)
+        | (price_ratios < 1 / MAX_REASONABLE_DAILY_PRICE_RATIO)
+    ].index
+    if len(discontinuities) > 0:
+        cleaned = cleaned.loc[discontinuities[-1]:]
+
+    return cleaned
 
 
 def plot_stock_data_base64(ticker_symbols):
@@ -144,8 +171,9 @@ def plot_stock_data_base64(ticker_symbols):
         try:
             stock = yf.Ticker(ticker_symbol)
             hist = stock.history(**history_options)
+            hist = clean_price_history(hist)
             if hist.empty:
-                print(f"No historical data found for {ticker_symbol}")
+                print(f"No usable historical close prices found for {ticker_symbol}")
                 continue
 
             hist["Normalized"] = (hist["Close"] / hist["Close"].iloc[0]) * 100

--- a/tests/test_ticker_handler.py
+++ b/tests/test_ticker_handler.py
@@ -2,11 +2,13 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
+import pytest
 
 from handlers.ticker_handler import (
     DEFAULT_DURATION,
     duration_to_timedelta,
     extract_ticker_symbols,
+    clean_price_history,
     get_history_options,
     plot_stock_data_base64,
 )
@@ -35,6 +37,7 @@ def test_get_history_options_uses_requested_range_and_hourly_intraday():
     assert hourly_options == {
         "start": now - timedelta(days=4),
         "end": now,
+        "auto_adjust": False,
         "interval": "1h",
     }
 
@@ -42,6 +45,7 @@ def test_get_history_options_uses_requested_range_and_hourly_intraday():
     assert daily_options == {
         "start": now - timedelta(days=10),
         "end": now,
+        "auto_adjust": False,
     }
 
 
@@ -61,10 +65,106 @@ def test_plot_uses_longest_requested_range_and_prices_in_legend(mock_ticker, moc
 
     assert result == "encoded-plot"
     history_kwargs = ticker_instance.history.call_args.kwargs
-    assert set(history_kwargs) == {"start", "end"}
+    assert set(history_kwargs) == {"start", "end", "auto_adjust"}
+    assert history_kwargs["auto_adjust"] is False
     actual_range = history_kwargs["end"] - history_kwargs["start"]
     assert timedelta(days=9, hours=23, minutes=59) < actual_range < timedelta(days=10, minutes=1)
     assert mock_ticker.call_count == 2
     assert mock_plt.text.call_count == 0
     labels = [call.kwargs["label"] for call in mock_plt.plot.call_args_list]
     assert labels == ["SPY ($10.00 → $12.00)", "AMD ($10.00 → $12.00)"]
+
+
+def test_clean_price_history_removes_zero_and_missing_close_values():
+    hist = pd.DataFrame(
+        {"Close": [10.0, None, 0.0, 12.0]},
+        index=pd.date_range("2026-06-01", periods=4, tz="UTC"),
+    )
+
+    cleaned = clean_price_history(hist)
+
+    assert cleaned["Close"].tolist() == [10.0, 12.0]
+
+
+def test_clean_price_history_keeps_recent_segment_for_spcm_style_reused_ticker_data():
+    hist = pd.DataFrame(
+        {"Close": [2500000.0, 2600000.0, 28.50, 32.34]},
+        index=pd.date_range("2026-06-11", periods=4, tz="UTC"),
+    )
+
+    cleaned = clean_price_history(hist)
+
+    assert cleaned["Close"].tolist() == [28.50, 32.34]
+
+
+def test_clean_price_history_keeps_recent_segment_for_spcg_style_reused_ticker_data():
+    hist = pd.DataFrame(
+        {"Close": [1800000.0, 1750000.0, 20.75, 15.31]},
+        index=pd.date_range("2026-06-11", periods=4, tz="UTC"),
+    )
+
+    cleaned = clean_price_history(hist)
+
+    assert cleaned["Close"].tolist() == [20.75, 15.31]
+
+
+@patch("handlers.ticker_handler.file_to_base64", return_value="encoded-plot")
+@patch("handlers.ticker_handler.plt")
+@patch("handlers.ticker_handler.yf.Ticker")
+def test_plot_ignores_zero_close_rows_when_labeling_and_normalizing(mock_ticker, mock_plt, mock_file_to_base64):
+    hist = pd.DataFrame(
+        {"Close": [10.0, 11.0, 0.0]},
+        index=pd.date_range("2026-06-01", periods=3, tz="UTC"),
+    )
+    ticker_instance = MagicMock()
+    ticker_instance.history.return_value = hist
+    mock_ticker.return_value = ticker_instance
+
+    result = plot_stock_data_base64([("SPCM", "10d")])
+
+    assert result == "encoded-plot"
+    labels = [call.kwargs["label"] for call in mock_plt.plot.call_args_list]
+    assert labels == ["SPY ($10.00 → $11.00)", "SPCM ($10.00 → $11.00)"]
+    plotted_values = [call.args[1].tolist() for call in mock_plt.plot.call_args_list]
+    assert plotted_values[0] == pytest.approx([100.0, 110.0])
+    assert plotted_values[1] == pytest.approx([100.0, 110.0])
+
+
+@patch("handlers.ticker_handler.file_to_base64", return_value="encoded-plot")
+@patch("handlers.ticker_handler.plt")
+@patch("handlers.ticker_handler.yf.Ticker")
+def test_plot_spcm_and_spcg_use_recent_continuous_price_segments(mock_ticker, mock_plt, mock_file_to_base64):
+    histories = {
+        "SPY": pd.DataFrame(
+            {"Close": [100.0, 101.0, 102.0, 103.0]},
+            index=pd.date_range("2026-06-11", periods=4, tz="UTC"),
+        ),
+        "SPCM": pd.DataFrame(
+            {"Close": [2500000.0, 2600000.0, 28.50, 32.34]},
+            index=pd.date_range("2026-06-11", periods=4, tz="UTC"),
+        ),
+        "SPCG": pd.DataFrame(
+            {"Close": [1800000.0, 1750000.0, 20.75, 15.31]},
+            index=pd.date_range("2026-06-11", periods=4, tz="UTC"),
+        ),
+    }
+
+    def ticker_factory(symbol):
+        ticker = MagicMock()
+        ticker.history.return_value = histories[symbol.upper()]
+        return ticker
+
+    mock_ticker.side_effect = ticker_factory
+
+    result = plot_stock_data_base64([("SPCM", "1y"), ("SPCG", "1y")])
+
+    assert result == "encoded-plot"
+    labels = [call.kwargs["label"] for call in mock_plt.plot.call_args_list]
+    assert labels == [
+        "SPY ($100.00 → $103.00)",
+        "SPCM ($28.50 → $32.34)",
+        "SPCG ($20.75 → $15.31)",
+    ]
+    plotted_values = [call.args[1].tolist() for call in mock_plt.plot.call_args_list]
+    assert plotted_values[1] == pytest.approx([100.0, 113.4736842])
+    assert plotted_values[2] == pytest.approx([100.0, 73.7831325])


### PR DESCRIPTION
### Motivation

- Prevent misleading plots and labels caused by stale or predecessor history rows in Yahoo data that include zero/NA closes or extreme price discontinuities. 
- Ensure plotted normalization uses raw close prices rather than adjusted values to keep legends and calculations consistent.

### Description

- Add `MAX_REASONABLE_DAILY_PRICE_RATIO` constant and set `auto_adjust` to `False` in `get_history_options` so `yf.Ticker.history` returns unadjusted close prices. 
- Implement `clean_price_history` to drop NA/zero closes and trim to the most recent continuous price segment when an extreme discontinuity is detected by comparing adjacent close ratios. 
- Integrate `clean_price_history` into `plot_stock_data_base64` and update the no-data log message to reflect unusable close prices. 
- Update tests in `tests/test_ticker_handler.py` to cover `clean_price_history`, zero/NA handling, discontinuity trimming, and the addition of `auto_adjust` to history options.

### Testing

- Ran unit tests in `tests/test_ticker_handler.py` with `pytest` which include new tests for `clean_price_history` and updated plotting behaviors. 
- All added and existing tests passed locally using the test suite. 
- Mocked `yfinance` and `matplotlib` in tests to validate labeling, normalization, and history option usage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31deb64d6c832682160ac63a201575)