### PR TITLE
Ensure image-generation returns safe message and normalize handler outputs

### DIFF
--- a/handlers/gpt_handler.py
+++ b/handlers/gpt_handler.py
@@ -451,7 +451,7 @@ def is_image_model(model_name: str) -> bool:
 
 def submit_gpt_image_gen(user_input, session_key=None, model=DEFAULT_IMAGE_MODEL):
     if session_key:
-        return []
+        return {"message": "Image generation does not use conversation history.", "attachments": []}
 
     try:
         response = client.images.generate(
@@ -484,7 +484,11 @@ def submit_gpt_image_gen(user_input, session_key=None, model=DEFAULT_IMAGE_MODEL
     if revised_prompt is None and isinstance(image_data, dict):
         revised_prompt = image_data.get("revised_prompt")
 
-    return {"message": revised_prompt, "attachments": [image_b64] if image_b64 else []}
+    message = revised_prompt or "Generated image attached."
+    if not image_b64:
+        message = f"{message} No image data was returned by the image API."
+
+    return {"message": message, "attachments": [image_b64] if image_b64 else []}
 
 
 import requests

--- a/run.py
+++ b/run.py
@@ -282,8 +282,8 @@ class TurboBotCommand(Command):
                         returnMsg = ""
                         try:
                             retdict = handler.process_message(msg, b64_attachments)
-                            returnMsg = retdict["message"]
-                            returnAttachments = retdict["attachments"]
+                            returnMsg = retdict.get("message") or ""
+                            returnAttachments = retdict.get("attachments") or []
                             print(f"retmessage {returnMsg}")
                             print(f"attachment len {len(returnAttachments)}")
                         except Exception as e:

--- a/tests/test_gpt_handler.py
+++ b/tests/test_gpt_handler.py
@@ -76,6 +76,32 @@ class GptHandlerImageModelTest(unittest.TestCase):
         self.assertEqual(response, {"message": "ok", "attachments": []})
         submit_mock.assert_called_once_with("draw a tiny robot", None, DEFAULT_IMAGE_MODEL)
 
+    def test_image_generation_returns_fallback_message_without_revised_prompt(self):
+        class ImageData:
+            b64_json = "abc123"
+            revised_prompt = None
+
+        class Response:
+            data = [ImageData()]
+
+        handler = GptHandler("#gpt.image draw a tiny robot")
+        self.assertTrue(handler.can_handle())
+
+        with patch("handlers.gpt_handler.client.images.generate", return_value=Response()):
+            response = handler.process_message("#gpt.image draw a tiny robot", None)
+
+        self.assertEqual(response, {"message": "Generated image attached.", "attachments": ["abc123"]})
+
+    def test_image_generation_session_key_returns_dict(self):
+        from handlers.gpt_handler import submit_gpt_image_gen
+
+        response = submit_gpt_image_gen("draw a tiny robot", session_key="chat")
+
+        self.assertEqual(
+            response,
+            {"message": "Image generation does not use conversation history.", "attachments": []},
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent the bot from crashing with "can only concatenate str (not \"NoneType\")" when image-generation returns a missing `revised_prompt` or when handlers return `None` for message/attachments.

### Description
- Change `submit_gpt_image_gen` to return a consistent dictionary when `session_key` is provided: `{"message": "Image generation does not use conversation history.", "attachments": []}`.
- Use a safe fallback message `"Generated image attached."` when the image API returns `revised_prompt = None`, and annotate when no image data was returned while still returning the attachments list when available.
- Harden the reply path in `run.py` to normalize handler outputs by using `retdict.get("message") or ""` and `retdict.get("attachments") or []` before concatenation/sending.
- Add two regression tests to `tests/test_gpt_handler.py` covering the fallback message and `session_key` behavior for image generation.

### Testing
- Ran `python -m unittest tests/test_gpt_handler.py` which passed.
- Attempted `python -m unittest discover -s tests` which exercised the test suite but reported failures due to environment-dependent network/proxy issues and unrelated handler assertions; those failures are external to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bd074e3fc832695ec8d2207408028)