### PR TITLE
Prevent yt-dlp transcodes from inflating small files

### DIFF
--- a/tests/test_twitter_handler_format_selection.py
+++ b/tests/test_twitter_handler_format_selection.py
@@ -11,9 +11,41 @@ from handlers.twitter_handler import (
     _stream_tail_download_ranges,
     download_video,
 )
+from utils.misc_utils import _mp4_video_bitrate, convert_to_mp4
 
 
 class TwitterHandlerFormatSelectionTest(unittest.TestCase):
+    def test_transcode_bitrate_uses_input_size_when_smaller_than_max(self):
+        input_size_bytes = 13 * 1024 * 1024
+        duration_seconds = 60
+
+        max_budget_bitrate = _mp4_video_bitrate(90 * 1024 * 1024, duration_seconds)
+        input_size_bitrate = _mp4_video_bitrate(input_size_bytes, duration_seconds)
+
+        self.assertEqual(input_size_bitrate, "1647k")
+        self.assertNotEqual(input_size_bitrate, max_budget_bitrate)
+
+    @patch("utils.misc_utils.os.path.getsize", return_value=12 * 1024 * 1024)
+    @patch("utils.misc_utils.ffmpeg")
+    def test_convert_to_mp4_targets_input_size_not_full_max_budget(self, ffmpeg_mock, _):
+        input_size_bytes = 13 * 1024 * 1024
+        ffmpeg_mock.probe.return_value = {
+            "format": {
+                "format_name": "mov,mp4,m4a,3gp,3g2,mj2",
+                "duration": "60",
+                "size": str(input_size_bytes),
+            },
+            "streams": [
+                {"codec_type": "video", "width": 640, "height": 360},
+            ],
+        }
+        ffmpeg_mock.input.return_value.output.return_value.run.return_value = None
+
+        convert_to_mp4("downloaded_video.mp4.in", "downloaded_video.mp4", 90)
+
+        output_kwargs = ffmpeg_mock.input.return_value.output.call_args.kwargs
+        self.assertEqual(output_kwargs["video_bitrate"], "1647k")
+
     def test_youtube_probe_uses_android_vr_client_for_split_formats(self):
         opts = _base_ydl_opts()
 

--- a/utils/misc_utils.py
+++ b/utils/misc_utils.py
@@ -227,6 +227,11 @@ def get_current_branch_name():
         return None
 
 
+def _mp4_video_bitrate(target_size_bytes: int, duration_seconds: float, audio_bitrate_kbps: int = 128):
+    target_total_kbps = (target_size_bytes * 8) / duration_seconds / 1024
+    return f"{max(round(target_total_kbps - audio_bitrate_kbps), 150)}k"
+
+
 def convert_to_mp4(input_file: str, output_file: str, max_size_mb: int, max_resolution: tuple = (1280, 720)):
     """
     Convert a video file to MP4 format while ensuring it does not exceed a specified file size
@@ -256,16 +261,13 @@ def convert_to_mp4(input_file: str, output_file: str, max_size_mb: int, max_reso
     original_width = int(video_stream['width'])
     original_height = int(video_stream['height'])
 
-    # Calculate target bitrate (bits per second) to fit within max size
+    # Calculate target bitrate against the smaller of the upload limit and input
+    # size. This keeps required iPhone-compatible transcoding from expanding small
+    # downloads up to the much larger max file size budget.
     max_size_bytes = max_size_mb * 1024 * 1024
-    bitrate = (max_size_bytes * 8) / duration  # bits per second
-
-    # Ensure a minimum bitrate threshold
-    #min_bitrate = 150000  # 150 kbps
-    #bitrate = max(bitrate, min_bitrate)
-    
-    bitrate = bitrate / 1024
-    bitrate = str(round(bitrate)-128) + "k"
+    input_size_bytes = int(probe['format']['size'])
+    target_size_bytes = min(max_size_bytes, input_size_bytes)
+    bitrate = _mp4_video_bitrate(target_size_bytes, duration)
 
     # Adjust resolution if it exceeds max_resolution
     target_width, target_height = original_width, original_height
@@ -288,6 +290,21 @@ def convert_to_mp4(input_file: str, output_file: str, max_size_mb: int, max_reso
         vf=f"scale={target_width}:{target_height}",
         format="mp4"
     ).run(overwrite_output=True)
+
+    if os.path.getsize(output_file) > input_size_bytes:
+        lower_bitrate = _mp4_video_bitrate(int(input_size_bytes * 0.90), duration)
+        ffmpeg.input(input_file).output(
+            output_file,
+            vcodec="libx264",
+            acodec="aac",
+            video_bitrate=lower_bitrate,
+            audio_bitrate="128k",
+            vf=f"scale={target_width}:{target_height}",
+            format="mp4"
+        ).run(overwrite_output=True)
+
+    if os.path.getsize(output_file) > input_size_bytes:
+        raise ValueError("Transcoded MP4 is larger than the original download.")
 
     return output_file
 


### PR DESCRIPTION
### Motivation
- Prevent an unintended regression where downloaded videos (e.g. ~13MB) were being transcoded up to the full upload budget (e.g. ~90MB) while preserving the iPhone-compatible transcode behavior.

### Description
- Add a helper `_mp4_video_bitrate` and compute the transcode bitrate using the smaller of the configured max upload budget and the original downloaded file size so small inputs are not expanded.
- Update `convert_to_mp4` to target the input-size-based bitrate and keep the existing resolution limiting behavior.
- Retry the transcode with a reduced (90%) input-size target if the first transcode produces an output larger than the source, and raise a `ValueError` if the transcoded file remains larger than the original.
- Add unit tests in `tests/test_twitter_handler_format_selection.py` to cover the bitrate calculation and to assert `convert_to_mp4` targets the input-size-derived bitrate.

### Testing
- Ran `python -m unittest tests/test_twitter_handler_format_selection.py`, which passed (`Ran 13 tests` and `OK`).
- Ran `git diff --check`, which reported no problems.
- Ran `python -m unittest discover tests` in this environment, which surfaced unrelated import errors due to a missing local `signalbot` dependency; those failures are environmental and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4669c69804832697f91f23631e1751)