### PR TITLE
Prefer iPhone-compatible MP4 formats and skip unnecessary transcoding

### DIFF
--- a/handlers/twitter_handler.py
+++ b/handlers/twitter_handler.py
@@ -86,49 +86,90 @@ def _format_filesize_bytes(fmt):
     return int(size or 0)
 
 
+def _is_h264_codec(codec):
+    return (codec or "").lower().split(".", 1)[0] in {"avc1", "avc3", "h264"}
+
+
+def _is_aac_codec(codec):
+    return (codec or "").lower().split(".", 1)[0] in {"mp4a", "aac"}
+
+
+def _is_iphone_compatible_format(fmt):
+    if fmt.get("ext") != "mp4":
+        return False
+
+    vcodec = fmt.get("vcodec")
+    acodec = fmt.get("acodec")
+    has_video = vcodec and vcodec != "none"
+    has_audio = acodec and acodec != "none"
+
+    if has_video and not _is_h264_codec(vcodec):
+        return False
+    if has_audio and not _is_aac_codec(acodec):
+        return False
+    return has_video or has_audio
+
+
+def _pick_largest_format_id(formats, max_bytes, compatible_only=False):
+    best_format = None
+    best_size = -1
+    for fmt in formats:
+        size = _format_filesize_bytes(fmt)
+        if not size or size > max_bytes:
+            continue
+        if compatible_only and not _is_iphone_compatible_format(fmt):
+            continue
+        if size > best_size:
+            best_format = fmt["format_id"]
+            best_size = size
+    return best_format
+
+
+def _pick_best_format_pair(video_formats, audio_formats, max_bytes, compatible_only=False):
+    best_pair = None
+    best_pair_size = -1
+    for video_fmt in video_formats:
+        if video_fmt.get("ext") != "mp4":
+            continue
+        if compatible_only and not _is_h264_codec(video_fmt.get("vcodec")):
+            continue
+        for audio_fmt in audio_formats:
+            if audio_fmt.get("ext") != "m4a":
+                continue
+            if compatible_only and not _is_aac_codec(audio_fmt.get("acodec")):
+                continue
+            total_size = _format_filesize_bytes(video_fmt) + _format_filesize_bytes(audio_fmt)
+            if total_size <= max_bytes and total_size > best_pair_size:
+                best_pair = f'{video_fmt["format_id"]}+{audio_fmt["format_id"]}'
+                best_pair_size = total_size
+    return best_pair
+
+
 def _pick_best_download_format(formats, max_filesize_mb):
     max_bytes = max_filesize_mb * 1024 * 1024
 
-    best_muxed = None
-    best_muxed_size = -1
-    for fmt in formats:
-        size = _format_filesize_bytes(fmt)
-        has_video = fmt.get("vcodec") != "none"
-        has_audio = fmt.get("acodec") != "none"
-        if not (size and has_video and has_audio):
-            continue
-        if size <= max_bytes and size > best_muxed_size:
-            best_muxed = fmt["format_id"]
-            best_muxed_size = size
-
-    if best_muxed:
-        return best_muxed
-
+    muxed_formats = []
     video_formats = []
     audio_formats = []
     for fmt in formats:
         size = _format_filesize_bytes(fmt)
         if not size:
             continue
-        if fmt.get("vcodec") != "none" and fmt.get("acodec") == "none":
+        has_video = fmt.get("vcodec") != "none"
+        has_audio = fmt.get("acodec") != "none"
+        if has_video and has_audio:
+            muxed_formats.append(fmt)
+        elif has_video:
             video_formats.append(fmt)
-        elif fmt.get("acodec") != "none" and fmt.get("vcodec") == "none":
+        elif has_audio:
             audio_formats.append(fmt)
 
-    best_pair = None
-    best_pair_size = -1
-    for video_fmt in video_formats:
-        if video_fmt.get("ext") != "mp4":
-            continue
-        for audio_fmt in audio_formats:
-            if audio_fmt.get("ext") != "m4a":
-                continue
-            total_size = _format_filesize_bytes(video_fmt) + _format_filesize_bytes(audio_fmt)
-            if total_size <= max_bytes and total_size > best_pair_size:
-                best_pair = f'{video_fmt["format_id"]}+{audio_fmt["format_id"]}'
-                best_pair_size = total_size
-
-    return best_pair
+    return (
+        _pick_largest_format_id(muxed_formats, max_bytes, compatible_only=True)
+        or _pick_best_format_pair(video_formats, audio_formats, max_bytes, compatible_only=True)
+        or _pick_largest_format_id(muxed_formats, max_bytes)
+        or _pick_best_format_pair(video_formats, audio_formats, max_bytes)
+    )
 
 
 def _live_status(info):
@@ -254,7 +295,7 @@ def download_video(url, max_filesize_mb=90, suggested_filename="downloaded_video
     else:
         print("No suitable format found. Downloading best quality and compressing if needed.")
         ydl_opts = {
-            'format': 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best',
+            'format': 'bestvideo[ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a][acodec^=mp4a]/best[ext=mp4][vcodec^=avc1][acodec^=mp4a]/bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best',
             'progress_hooks': [progress_hook],
             'outtmpl': f'{suggested_filename}.%(ext)s',
             'postprocessors': [{

--- a/tests/test_twitter_handler_format_selection.py
+++ b/tests/test_twitter_handler_format_selection.py
@@ -46,6 +46,49 @@ class TwitterHandlerFormatSelectionTest(unittest.TestCase):
         output_kwargs = ffmpeg_mock.input.return_value.output.call_args.kwargs
         self.assertEqual(output_kwargs["video_bitrate"], "1647k")
 
+
+    @patch("utils.misc_utils.ffmpeg")
+    def test_convert_to_mp4_skips_iphone_compatible_mp4(self, ffmpeg_mock):
+        ffmpeg_mock.probe.return_value = {
+            "format": {
+                "format_name": "mov,mp4,m4a,3gp,3g2,mj2",
+                "duration": "60",
+                "size": str(13 * 1024 * 1024),
+            },
+            "streams": [
+                {"codec_type": "video", "codec_name": "h264", "width": 640, "height": 360},
+                {"codec_type": "audio", "codec_name": "aac"},
+            ],
+        }
+
+        result = convert_to_mp4("downloaded_video.mp4.in", "downloaded_video.mp4", 90)
+
+        self.assertEqual(result, "downloaded_video.mp4.in")
+        ffmpeg_mock.input.assert_not_called()
+
+    @patch("utils.misc_utils.os.path.getsize", return_value=12 * 1024 * 1024)
+    @patch("utils.misc_utils.ffmpeg")
+    def test_convert_to_mp4_transcodes_mp4_with_unsupported_video_codec(self, ffmpeg_mock, _):
+        ffmpeg_mock.probe.return_value = {
+            "format": {
+                "format_name": "mov,mp4,m4a,3gp,3g2,mj2",
+                "duration": "60",
+                "size": str(13 * 1024 * 1024),
+            },
+            "streams": [
+                {"codec_type": "video", "codec_name": "av1", "width": 640, "height": 360},
+                {"codec_type": "audio", "codec_name": "aac"},
+            ],
+        }
+        ffmpeg_mock.input.return_value.output.return_value.run.return_value = None
+
+        result = convert_to_mp4("downloaded_video.mp4.in", "downloaded_video.mp4", 90)
+
+        self.assertEqual(result, "downloaded_video.mp4")
+        output_kwargs = ffmpeg_mock.input.return_value.output.call_args.kwargs
+        self.assertEqual(output_kwargs["vcodec"], "libx264")
+        self.assertEqual(output_kwargs["acodec"], "aac")
+
     def test_youtube_probe_uses_android_vr_client_for_split_formats(self):
         opts = _base_ydl_opts()
 
@@ -54,22 +97,33 @@ class TwitterHandlerFormatSelectionTest(unittest.TestCase):
             ["android", "android_vr"],
         )
 
-    def test_prefers_largest_muxed_format_under_limit(self):
+    def test_prefers_largest_compatible_muxed_format_under_limit(self):
         formats = [
-            {"format_id": "small", "filesize": 10 * 1024 * 1024, "vcodec": "avc1", "acodec": "mp4a"},
-            {"format_id": "best", "filesize": 80 * 1024 * 1024, "vcodec": "avc1", "acodec": "mp4a"},
-            {"format_id": "too_big", "filesize": 120 * 1024 * 1024, "vcodec": "avc1", "acodec": "mp4a"},
+            {"format_id": "small", "ext": "mp4", "filesize": 10 * 1024 * 1024, "vcodec": "avc1", "acodec": "mp4a"},
+            {"format_id": "best", "ext": "mp4", "filesize": 80 * 1024 * 1024, "vcodec": "avc1.64001f", "acodec": "mp4a.40.2"},
+            {"format_id": "larger_av1", "ext": "mp4", "filesize": 85 * 1024 * 1024, "vcodec": "av01", "acodec": "mp4a"},
+            {"format_id": "too_big", "ext": "mp4", "filesize": 120 * 1024 * 1024, "vcodec": "avc1", "acodec": "mp4a"},
         ]
 
         self.assertEqual(_pick_best_download_format(formats, 90), "best")
 
-    def test_falls_back_to_mp4_video_plus_m4a_audio_pair_under_limit(self):
+    def test_falls_back_to_compatible_mp4_video_plus_m4a_audio_pair_under_limit(self):
         formats = [
             {"format_id": "137", "ext": "mp4", "filesize": 100 * 1024 * 1024, "vcodec": "avc1", "acodec": "none"},
             {"format_id": "399", "ext": "mp4", "filesize": 60 * 1024 * 1024, "vcodec": "av01", "acodec": "none"},
+            {"format_id": "398", "ext": "mp4", "filesize": 50 * 1024 * 1024, "vcodec": "avc1.4d401f", "acodec": "none"},
             {"format_id": "248", "ext": "webm", "filesize": 50 * 1024 * 1024, "vcodec": "vp9", "acodec": "none"},
-            {"format_id": "140", "ext": "m4a", "filesize": 20 * 1024 * 1024, "vcodec": "none", "acodec": "mp4a"},
+            {"format_id": "140", "ext": "m4a", "filesize": 20 * 1024 * 1024, "vcodec": "none", "acodec": "mp4a.40.2"},
             {"format_id": "251", "ext": "webm", "filesize": 10 * 1024 * 1024, "vcodec": "none", "acodec": "opus"},
+        ]
+
+        self.assertEqual(_pick_best_download_format(formats, 90), "398+140")
+
+    def test_falls_back_to_incompatible_format_when_no_compatible_choice_fits(self):
+        formats = [
+            {"format_id": "137", "ext": "mp4", "filesize": 100 * 1024 * 1024, "vcodec": "avc1", "acodec": "none"},
+            {"format_id": "399", "ext": "mp4", "filesize": 60 * 1024 * 1024, "vcodec": "av01", "acodec": "none"},
+            {"format_id": "140", "ext": "m4a", "filesize": 20 * 1024 * 1024, "vcodec": "none", "acodec": "mp4a"},
         ]
 
         self.assertEqual(_pick_best_download_format(formats, 90), "399+140")

--- a/utils/misc_utils.py
+++ b/utils/misc_utils.py
@@ -232,6 +232,33 @@ def _mp4_video_bitrate(target_size_bytes: int, duration_seconds: float, audio_bi
     return f"{max(round(target_total_kbps - audio_bitrate_kbps), 150)}k"
 
 
+def _is_mp4_container(format_name: str):
+    return "mp4" in {name.strip().lower() for name in format_name.split(",")}
+
+
+def _is_iphone_compatible_mp4(probe, max_size_mb: int, max_resolution: tuple):
+    format_info = probe["format"]
+    if not _is_mp4_container(format_info.get("format_name", "")):
+        return False
+
+    if int(format_info.get("size", 0)) > max_size_mb * 1024 * 1024:
+        return False
+
+    video_stream = next((stream for stream in probe["streams"] if stream["codec_type"] == "video"), None)
+    if not video_stream:
+        return False
+
+    if int(video_stream["width"]) > max_resolution[0] or int(video_stream["height"]) > max_resolution[1]:
+        return False
+
+    video_codec = video_stream.get("codec_name", "").lower()
+    if video_codec not in {"h264"}:
+        return False
+
+    audio_streams = [stream for stream in probe["streams"] if stream["codec_type"] == "audio"]
+    return all(stream.get("codec_name", "").lower() == "aac" for stream in audio_streams)
+
+
 def convert_to_mp4(input_file: str, output_file: str, max_size_mb: int, max_resolution: tuple = (1280, 720)):
     """
     Convert a video file to MP4 format while ensuring it does not exceed a specified file size
@@ -260,6 +287,9 @@ def convert_to_mp4(input_file: str, output_file: str, max_size_mb: int, max_reso
 
     original_width = int(video_stream['width'])
     original_height = int(video_stream['height'])
+
+    if _is_iphone_compatible_mp4(probe, max_size_mb, max_resolution):
+        return input_file
 
     # Calculate target bitrate against the smaller of the upload limit and input
     # size. This keeps required iPhone-compatible transcoding from expanding small


### PR DESCRIPTION
### Motivation

- Improve format selection to prefer iPhone-compatible MP4s (H.264 video + AAC audio) under the size limit to avoid needless re-encoding and ensure better playback compatibility.
- Avoid upscaling small downloads to the full upload budget during transcoding by preserving size-aware bitrate targeting.
- Ensure the downloader prioritizes container/codec compatibility to reduce post-download processing and CPU use.

### Description

- Added codec/container checks and helpers: `_is_h264_codec`, `_is_aac_codec`, `_is_iphone_compatible_format`, and `_is_mp4_container` and refactored selection into `_pick_largest_format_id`, `_pick_best_format_pair`, and rewritten `_pick_best_download_format` to prefer compatible mp4 muxed formats and mp4 video+m4a audio pairs before falling back to non-compatible choices.
- Updated the default `yt_dlp` format string to prefer `avc1`/`mp4a`-based mp4 variants when no under-limit format is selected and constrained download options are used.
- Enhanced `convert_to_mp4` with `_is_iphone_compatible_mp4` to short-circuit and return the original file when it is already an iPhone-compatible MP4 under size/resolution limits, while preserving the existing bitrate/resolution adjustment and two-pass fallback transcode behavior.
- Updated unit tests in `tests/test_twitter_handler_format_selection.py` to assert the new compatibility-first selection behavior and added tests for `convert_to_mp4` to verify skipping and forced transcoding for unsupported codecs.

### Testing

- Ran the updated unit tests in `tests/test_twitter_handler_format_selection.py` (mocking `ffmpeg` and file sizes) and all tests passed.
- Exercised `convert_to_mp4` logic via mocked `ffmpeg.probe` and `ffmpeg` calls to validate both skip-path and transcode-path behaviors and those assertions succeeded.
- Exercised `_pick_best_download_format` selection scenarios via unit tests covering compatible muxed formats, compatible video+audio pairs, and fallback to incompatible choices, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f7cf1beb08326b378faa1e16a50e5)