### PR TITLE
Make Reddit video download resilient and re-raise shutdown exceptions

### DIFF
--- a/run.py
+++ b/run.py
@@ -241,7 +241,13 @@ class TurboBotCommand(Command):
             return
         elif (url := is_reddit_domain(msg)):
             print("is reddit url")
-            video_b64 = download_reddit_video_tryall_b64(url)            
+            try:
+                video_b64 = download_reddit_video_tryall_b64(url)
+            except BaseException as ex:
+                if is_shutdown_exception(ex):
+                    raise
+                print(f"Reddit download failed without crashing bot: {ex}")
+                video_b64 = None
             if (video_b64):
                 await c.reply(  LOGMSG + "Reddit URL: " + url, base64_attachments=[video_b64])
         elif msg == "#":

--- a/tests/test_reddit_utils.py
+++ b/tests/test_reddit_utils.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from utils.reddit_utils import (
     download_reddit_video,
+    download_reddit_video_tryall_b64,
     download_reddit_video_with_redvid,
     is_reddit_domain,
     normalize_reddit_url,
@@ -140,6 +141,43 @@ class RedditUtilsTest(unittest.TestCase):
             )
 
         self.assertEqual(filename, "/repo/reddit.mp4")
+
+    @patch("utils.reddit_utils.Downloader")
+    def test_redvid_fallback_handles_redvid_base_exception(self, downloader_cls):
+        downloader = downloader_cls.return_value
+        downloader.download.side_effect = BaseException("Incorrect URL format")
+
+        with patch("utils.reddit_utils.os.remove"):
+            self.assertIsNone(
+                download_reddit_video_with_redvid(
+                    "https://www.reddit.com/comments/6rrwyj/",
+                    "reddit.mp4",
+                )
+            )
+
+    @patch("utils.reddit_utils.get_video_as_base64", return_value=None)
+    @patch("utils.reddit_utils.download_reddit_video", side_effect=Exception("yt-dlp failed"))
+    def test_tryall_b64_handles_downloader_exception(self, download_mock, scrape_mock):
+        self.assertIsNone(download_reddit_video_tryall_b64("https://redd.it/6rrwyj"))
+        self.assertEqual(
+            [call.args[0] for call in download_mock.call_args_list],
+            ["https://www.reddit.com/comments/6rrwyj/", "https://redd.it/6rrwyj"],
+        )
+        self.assertEqual(
+            [call.args[0] for call in scrape_mock.call_args_list],
+            ["https://www.reddit.com/comments/6rrwyj/", "https://redd.it/6rrwyj"],
+        )
+
+    @patch("utils.reddit_utils.Downloader")
+    def test_redvid_fallback_reraises_shutdown_exceptions(self, downloader_cls):
+        downloader = downloader_cls.return_value
+        downloader.download.side_effect = KeyboardInterrupt()
+
+        with patch("utils.reddit_utils.os.remove"), self.assertRaises(KeyboardInterrupt):
+            download_reddit_video_with_redvid(
+                "https://www.reddit.com/comments/6rrwyj/",
+                "reddit.mp4",
+            )
 
 
 if __name__ == "__main__":

--- a/utils/reddit_utils.py
+++ b/utils/reddit_utils.py
@@ -77,6 +77,10 @@ def is_reddit_domain(msg):
         #print("is NOT reddit url")
         return None
  
+def is_shutdown_exception(ex):
+    return isinstance(ex, (KeyboardInterrupt, SystemExit, GeneratorExit))
+
+
 def download_reddit_video_tryall_b64(url):
     normalized_url = normalize_reddit_url(url)
     urls_to_try = [normalized_url or url]
@@ -136,7 +140,9 @@ def download_reddit_video_with_redvid(url, fname="reddit.mp4"):
         reddit.filename = fname
         reddit.download()
         return os.path.abspath(fname)
-    except Exception as ex:
+    except BaseException as ex:
+        if is_shutdown_exception(ex):
+            raise
         print(ex)
         return None
         


### PR DESCRIPTION
### Motivation
- Prevent Reddit video download failures from crashing the bot while ensuring genuine shutdown signals still propagate.
- Ensure the fallback downloader path is robust to unexpected errors and that the bot continues operating when downloads fail.

### Description
- Added `is_shutdown_exception` helper to detect `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit` and use it to re-raise shutdown signals.  
- Changed `download_reddit_video_with_redvid` to catch `BaseException`, re-raise shutdown exceptions via `is_shutdown_exception`, and otherwise log and return `None`.  
- Wrapped the call to `download_reddit_video_tryall_b64` in `run.py` with a `try/except BaseException` that re-raises shutdown exceptions and prevents non-shutdown errors from crashing the bot.  
- Added unit tests in `tests/test_reddit_utils.py` to cover fallback behavior, exception handling, and shutdown re-raise semantics; and exported/used `download_reddit_video_tryall_b64` in tests.

### Testing
- Ran the reddit utils unit tests with `python -m unittest tests/test_reddit_utils.py` and the suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58b466d7c4832695e180a0d89e866d)